### PR TITLE
[#36] [Backend] As a user, I can automatically re-authenticate if my access token expires

### DIFF
--- a/src/adapters/authAdapter.test.ts
+++ b/src/adapters/authAdapter.test.ts
@@ -35,7 +35,7 @@ describe('AuthAdapter', () => {
         .reply(200);
 
       expect(scope.isDone()).toBe(false);
-      await AuthAdapter.login({ ...testCredentials });
+      await AuthAdapter.loginWithEmailPassword({ ...testCredentials });
       expect(scope.isDone()).toBe(true);
     });
   });

--- a/src/adapters/authAdapter.test.ts
+++ b/src/adapters/authAdapter.test.ts
@@ -1,19 +1,12 @@
 import nock from 'nock';
 
-import AuthAdapter from './authAdapter';
+import AuthAdapter, { commonParams } from './authAdapter';
 
 /* eslint-disable camelcase */
-const testCredentials = {
+const mockLoginCredentials = {
   email: 'testemail@gmail.com',
   password: 'password123',
 };
-
-const commonLoginParams = {
-  grant_type: 'password',
-  client_id: process.env.REACT_APP_API_CLIENT_ID,
-  client_secret: process.env.REACT_APP_API_CLIENT_SECRET,
-};
-/* eslint-enable camelcase */
 
 describe('AuthAdapter', () => {
   afterAll(() => {
@@ -21,7 +14,7 @@ describe('AuthAdapter', () => {
     nock.restore();
   });
 
-  describe('login', () => {
+  describe('loginWithEmailPassword', () => {
     test('The login endpoint is called with credientials from the request', async () => {
       const scope = nock(`${process.env.REACT_APP_API_ENDPOINT}`)
         .defaultReplyHeaders({
@@ -29,13 +22,34 @@ describe('AuthAdapter', () => {
           'access-control-allow-credentials': 'true',
         })
         .post('/oauth/token', {
-          ...testCredentials,
-          ...commonLoginParams,
+          ...mockLoginCredentials,
+          ...commonParams,
+          grant_type: 'password',
         })
         .reply(200);
 
       expect(scope.isDone()).toBe(false);
-      await AuthAdapter.loginWithEmailPassword({ ...testCredentials });
+      await AuthAdapter.loginWithEmailPassword({ ...mockLoginCredentials });
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('loginWithRefreshToken', () => {
+    test('The refresh token endpoint is called with refresh token from the request', async () => {
+      const scope = nock(`${process.env.REACT_APP_API_ENDPOINT}`)
+        .defaultReplyHeaders({
+          'access-control-allow-origin': '*',
+          'access-control-allow-credentials': 'true',
+        })
+        .post('/oauth/token', {
+          refresh_token: 'refresh_token',
+          ...commonParams,
+          grant_type: 'refresh_token',
+        })
+        .reply(200);
+
+      expect(scope.isDone()).toBe(false);
+      await AuthAdapter.loginWithRefreshToken('refresh_token');
       expect(scope.isDone()).toBe(true);
     });
   });

--- a/src/adapters/authAdapter.ts
+++ b/src/adapters/authAdapter.ts
@@ -5,14 +5,19 @@ type LoginAuthType = {
   password: string;
 };
 
+/* eslint-disable camelcase */
+export const commonParams = {
+  client_id: process.env.REACT_APP_API_CLIENT_ID,
+  client_secret: process.env.REACT_APP_API_CLIENT_SECRET,
+};
+/* eslint-enable camelcase */
 class AuthAdapter extends BaseAdapter {
-  static loginWithEmailPassword(params: LoginAuthType) {
+  static loginWithEmailPassword(authParams: LoginAuthType) {
     /* eslint-disable camelcase */
     const requestParams = {
-      ...params,
+      ...commonParams,
+      ...authParams,
       grant_type: 'password',
-      client_id: process.env.REACT_APP_API_CLIENT_ID,
-      client_secret: process.env.REACT_APP_API_CLIENT_SECRET,
     };
     /* eslint-enable camelcase */
 
@@ -22,10 +27,9 @@ class AuthAdapter extends BaseAdapter {
   static loginWithRefreshToken(refreshToken: string) {
     /* eslint-disable camelcase */
     const requestParams = {
+      ...commonParams,
       refresh_token: refreshToken,
       grant_type: 'refresh_token',
-      client_id: process.env.REACT_APP_API_CLIENT_ID,
-      client_secret: process.env.REACT_APP_API_CLIENT_SECRET,
     };
     /* eslint-enable camelcase */
 

--- a/src/adapters/authAdapter.ts
+++ b/src/adapters/authAdapter.ts
@@ -6,11 +6,24 @@ type LoginAuthType = {
 };
 
 class AuthAdapter extends BaseAdapter {
-  static login(params: LoginAuthType) {
+  static loginWithEmailPassword(params: LoginAuthType) {
     /* eslint-disable camelcase */
     const requestParams = {
       ...params,
       grant_type: 'password',
+      client_id: process.env.REACT_APP_API_CLIENT_ID,
+      client_secret: process.env.REACT_APP_API_CLIENT_SECRET,
+    };
+    /* eslint-enable camelcase */
+
+    return this.prototype.postRequest('oauth/token', { data: requestParams });
+  }
+
+  static loginWithRefreshToken(refreshToken: string) {
+    /* eslint-disable camelcase */
+    const requestParams = {
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
       client_id: process.env.REACT_APP_API_CLIENT_ID,
       client_secret: process.env.REACT_APP_API_CLIENT_SECRET,
     };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,3 @@
 export const PASSWORD_MIN_LENGTH = 5;
+
+export const LOGIN_URL = '/login';

--- a/src/helpers/userToken.test.ts
+++ b/src/helpers/userToken.test.ts
@@ -1,4 +1,4 @@
-import { setToken, getToken } from './userToken';
+import { setToken, getToken, clearToken } from './userToken';
 
 /* eslint-disable camelcase */
 describe('setToken', () => {
@@ -24,6 +24,20 @@ describe('getToken', () => {
 
   test('Given a NON-existing UserToken in LocalStorage, returns an empty object', () => {
     expect(getToken()).toEqual({});
+  });
+});
+
+describe('clearToken', () => {
+  test('Given an existing UserToken in LocalStorage, removes the value', () => {
+    const testToken = { access_token: 'access_token', refresh_token: 'refesh_token' };
+
+    localStorage.setItem('UserToken', JSON.stringify(testToken));
+
+    expect(JSON.parse(localStorage.getItem('UserToken') as string)).toStrictEqual(testToken);
+
+    clearToken();
+
+    expect(JSON.parse(localStorage.getItem('UserToken') as string)).toBeNull();
   });
 });
 /* eslint-enable camelcase */

--- a/src/helpers/userToken.ts
+++ b/src/helpers/userToken.ts
@@ -1,14 +1,11 @@
-type UserToken =
-  | {
-      access_token: string;
-      refresh_token: string;
-    }
-  | '{}';
-
-export const getToken = (): UserToken => {
+export const getToken = () => {
   return JSON.parse(localStorage.getItem('UserToken') || '{}');
 };
 
-export const setToken = (token: UserToken) => {
+export const setToken = (token: { access_token: string; refresh_token: string }) => {
   localStorage.setItem('UserToken', JSON.stringify(token));
+};
+
+export const clearToken = () => {
+  localStorage.removeItem('UserToken');
 };

--- a/src/screens/Login/index.test.tsx
+++ b/src/screens/Login/index.test.tsx
@@ -59,7 +59,7 @@ describe('LoginScreen', () => {
   });
 
   test('given an empty email and password in the login form, displays both errors', async () => {
-    const mockLogin = jest.spyOn(AuthAdapter, 'login');
+    const mockLogin = jest.spyOn(AuthAdapter, 'loginWithEmailPassword');
 
     render(<LoginScreen />, { wrapper: BrowserRouter });
 
@@ -114,7 +114,7 @@ describe('LoginScreen', () => {
   });
 
   test('given INCORRECT credentials, displays the error from the API response', async () => {
-    const mockLogin = jest.spyOn(AuthAdapter, 'login');
+    const mockLogin = jest.spyOn(AuthAdapter, 'loginWithEmailPassword');
 
     render(<LoginScreen />, { wrapper: BrowserRouter });
 

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -32,7 +32,7 @@ function LoginScreen() {
 
   const performLogin = async () => {
     try {
-      const response = await AuthAdapter.login({ email: email, password: password });
+      const response = await AuthAdapter.loginWithEmailPassword({ email: email, password: password });
 
       const {
         attributes: { access_token: accessToken, refresh_token: refreshToken },


### PR DESCRIPTION
- Close: #36 

## What happened 👀

- [x] Include `access_token` in `Authorization` header on all requests
- [x] Request and store new `acces_token`  using refresh token upon `401` error, if token doesn't exist then redirect to `login` page.
- [ ] ~~Tests for Interceptors for Axios/Request manager~~ This will be combined into the PR https://github.com/liamstevens111/react-survey-ic/pull/34

## Insight 📝

The interceptor will run on all requests. If there was another third-party API used there I would probably refactor this in a way at the adapter level rather than all requests in requestManager

## Proof Of Work 📹

Show us the implementation: screenshots, GIFs, etc.
