### PR TITLE
[#19] [UI] As a user, when I am authenticated I can see the company logo and my profile image at the top of pages [#18] [#22] As a user, I can logout

### DIFF
--- a/cypress/integration/Authentication/login.spec.ts
+++ b/cypress/integration/Authentication/login.spec.ts
@@ -8,7 +8,7 @@ describe('User Authentication', () => {
   });
 
   context('login with email and password', () => {
-    it('given correct credentials, redirects to the home page', () => {
+    it('given correct credentials, redirects to the home page, shows user header', () => {
       cy.intercept('POST', 'api/v1/oauth/token', {
         statusCode: 200,
         fixture: 'Authentication/valid-credentials.json',
@@ -27,9 +27,11 @@ describe('User Authentication', () => {
       });
 
       cy.findByTestId('app-main-heading').should('be.visible');
+
+      cy.findByTestId('header-avatar').should('have.attr', 'src', 'valid_avatar_url');
     });
 
-    it('given INCORRECT credentials, shows login error', () => {
+    it('given INCORRECT credentials, shows login error, does NOT show user header', () => {
       cy.intercept('POST', 'api/v1/oauth/token', {
         statusCode: 400,
         fixture: 'Authentication/invalid-credentials.json',
@@ -52,6 +54,7 @@ describe('User Authentication', () => {
       });
 
       cy.findByTestId('app-main-heading').should('not.exist');
+      cy.findByTestId('header-avatar').should('not.exist');
     });
 
     it('given NO credentials entered, shows field validation errors', () => {

--- a/cypress/integration/Surveys/home.spec.ts
+++ b/cypress/integration/Surveys/home.spec.ts
@@ -1,0 +1,47 @@
+import { setItem } from '../../../src/helpers/localStorage';
+/* eslint-disable camelcase */
+const mockTokenData = {
+  access_token: 'test_access_token',
+  refresh_token: 'test_refresh_token',
+  token_type: 'Bearer',
+  expires_in: 7200,
+  created_at: 1677045997,
+};
+
+const mockUserProfileData = {
+  email: 'testemail@gmail.com',
+  name: 'TestName',
+  avatar_url: 'https://secure.gravatar.com/avatar/6733d09432e89459dba795de8312ac2d',
+};
+
+// TODO: Add re-fetching auth token and calling endpoint when
+describe('Home', () => {
+  context('Authentication token', () => {
+    it('with user tokens, displays home page and user header', () => {
+      setItem('UserProfile', { auth: mockTokenData, user: mockUserProfileData });
+
+      cy.visit('/');
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/');
+      });
+
+      cy.findByTestId('app-main-heading').should('be.visible');
+
+      cy.findByText('Home Screen').should('exist');
+      cy.findByText('Home Screen').should('be.visible');
+    });
+
+    it('WITHOUT user tokens, redirects to the login page', () => {
+      cy.visit('/');
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/login');
+      });
+
+      cy.findByTestId('app-main-heading').should('not.exist');
+
+      cy.findByText('Home Screen').should('not.exist');
+    });
+  });
+});

--- a/cypress/integration/Surveys/home.spec.ts
+++ b/cypress/integration/Surveys/home.spec.ts
@@ -14,7 +14,7 @@ const mockUserProfileData = {
   avatar_url: 'https://secure.gravatar.com/avatar/6733d09432e89459dba795de8312ac2d',
 };
 
-// TODO: Add re-fetching auth token and calling endpoint when
+// TODO: Add test for expired token for surveys are shown on home page (a further authenticated request required)
 describe('Home', () => {
   context('Authentication token', () => {
     it('with user tokens, displays home page and user header', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "danger": "10.9.0",
         "danger-plugin-istanbul-coverage": "1.6.2",
         "eslint": "8.11.0",
-        "jest-localstorage-mock": "^2.4.26",
+        "jest-localstorage-mock": "2.4.26",
         "nock": "13.3.0",
         "postcss": "8.4.21",
         "postcss-import": "14.1.0",

--- a/src/adapters/authAdapter.test.ts
+++ b/src/adapters/authAdapter.test.ts
@@ -81,4 +81,22 @@ describe('AuthAdapter', () => {
       expect(scope.isDone()).toBe(true);
     });
   });
+
+  describe('logout', () => {
+    test('The logout endpoint is called', async () => {
+      const token = 'access_token';
+
+      const scope = nock(`${process.env.REACT_APP_API_ENDPOINT}`)
+        .defaultReplyHeaders({
+          'access-control-allow-origin': '*',
+          'access-control-allow-credentials': 'true',
+        })
+        .post('/oauth/revoke')
+        .reply(200);
+
+      expect(scope.isDone()).toBe(false);
+      expect(await AuthAdapter.logout(token));
+      expect(scope.isDone()).toBe(true);
+    });
+  });
 });

--- a/src/adapters/authAdapter.ts
+++ b/src/adapters/authAdapter.ts
@@ -36,6 +36,17 @@ class AuthAdapter extends BaseAdapter {
     return this.prototype.postRequest('oauth/token', { data: requestParams });
   }
 
+  static logout(accessToken: string) {
+    /* eslint-disable camelcase */
+    const requestParams = {
+      ...commonParams,
+      token: accessToken,
+    };
+    /* eslint-enable camelcase */
+
+    return this.prototype.postRequest('oauth/revoke', { data: requestParams });
+  }
+
   static getUser() {
     return this.prototype.getRequest('me', {});
   }

--- a/src/adapters/authAdapter.ts
+++ b/src/adapters/authAdapter.ts
@@ -39,7 +39,7 @@ class AuthAdapter extends BaseAdapter {
   static logout(accessToken: string) {
     /* eslint-disable camelcase */
     const requestParams = {
-      ...commonParams,
+      ...OauthParams,
       token: accessToken,
     };
     /* eslint-enable camelcase */

--- a/src/components/Header/index.test.tsx
+++ b/src/components/Header/index.test.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable camelcase */
+import { BrowserRouter } from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { User } from 'types/User';
+
+import Header from '.';
+
+const mockUserProfileData = {
+  email: 'testemail@gmail.com',
+  name: 'TestName',
+  avatar_url: 'https://secure.gravatar.com/avatar/6733d09432e89459dba795de8312ac2d',
+};
+
+describe('Header', () => {
+  const user: User = { name: 'Test User', email: 'testemail@email.com', avatarUrl: mockUserProfileData.avatar_url };
+
+  test('renders a header on the page with sidebar interaction', async () => {
+    render(<Header user={user} />, { wrapper: BrowserRouter });
+
+    const profileImage = screen.getByTestId('header-avatar') as HTMLImageElement;
+    expect(profileImage).toBeInTheDocument();
+    expect(profileImage.src).toContain(mockUserProfileData.avatar_url);
+
+    expect(screen.queryByTestId('sidebar-avatar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('username')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Logout' })).not.toBeInTheDocument();
+
+    const sidebarButton = screen.getByTestId('open-sidebar');
+
+    await userEvent.click(sidebarButton);
+
+    expect(screen.getByTestId('sidebar-avatar')).toBeInTheDocument();
+    expect(screen.getByTestId('username')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Logout' })).toBeInTheDocument();
+
+    expect(screen.queryByTestId('header-avatar')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react';
+
+import logo from 'assets/images/logo.svg';
+import Sidebar from 'components/Sidebar';
 import { User } from 'types/User';
 
 type HeaderProps = {
@@ -5,10 +9,22 @@ type HeaderProps = {
 };
 
 function Header({ user }: HeaderProps) {
+  const [sidebarVisible, setSidebarVisible] = useState(false);
+
   return (
-    <header className="flex w-screen flex-row items-center justify-between p-0">
-      <div className="">Test logo for {user.email}</div>
-      <div className="profile-image">Test image for {user.name}</div>
+    <header className="fixed top-5 flex w-11/12 flex-row items-center justify-between p-0">
+      <div>
+        <img src={logo} alt="logo"></img>
+      </div>
+      <div onClick={() => setSidebarVisible(!sidebarVisible)} role="presentation">
+        {sidebarVisible ? (
+          <Sidebar user={user} />
+        ) : (
+          <div>
+            <img className="cursor-pointer rounded-full" height={36} width={36} src={user.avatarUrl} alt="profile"></img>
+          </div>
+        )}
+      </div>
     </header>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,16 @@
+import { User } from 'types/User';
+
+type HeaderProps = {
+  user: User;
+};
+
+function Header({ user }: HeaderProps) {
+  return (
+    <header className="flex w-screen flex-row items-center justify-between p-0">
+      <div className="">Test logo for {user.email}</div>
+      <div className="profile-image">Test image for {user.name}</div>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -16,12 +16,19 @@ function Header({ user }: HeaderProps) {
       <div>
         <img src={logo} alt="logo"></img>
       </div>
-      <div onClick={() => setSidebarVisible(!sidebarVisible)} role="presentation">
+      <div data-test-id="open-sidebar" onClick={() => setSidebarVisible(!sidebarVisible)} role="presentation">
         {sidebarVisible ? (
           <Sidebar user={user} />
         ) : (
           <div>
-            <img className="cursor-pointer rounded-full" height={36} width={36} src={user.avatarUrl} alt="profile"></img>
+            <img
+              data-test-id="header-avatar"
+              className="cursor-pointer rounded-full"
+              height={36}
+              width={36}
+              src={user.avatarUrl}
+              alt="profile"
+            ></img>
           </div>
         )}
       </div>

--- a/src/components/PrivateRoute/index.test.tsx
+++ b/src/components/PrivateRoute/index.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import PrivateRoute from '.';
 import { setItem, clearItem } from '../../helpers/localStorage';
@@ -31,14 +31,17 @@ describe('PrivateRoute', () => {
     render(<PrivateRoute />, { wrapper: MemoryRouter });
 
     expect(localStorage.getItem).toBeCalledWith('UserProfile');
+
+    // Only the header is rendered and not the outlet (home page)
+    // expect(screen.getByTestId('app-main-heading')).toBeVisible();
   });
 
   test.skip('renders a PrivateRoute', async () => {
     // Infinite loop
     render(<PrivateRoute />, { wrapper: MemoryRouter });
 
-    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading'));
+    expect(screen.getByTestId('loading')).toHaveTextContent('Loading');
 
-    expect(screen.getByTestId('loading'));
+    // expect(screen.getByTestId('loading')).not.toBeVisible();
   });
 });

--- a/src/components/PrivateRoute/index.tsx
+++ b/src/components/PrivateRoute/index.tsx
@@ -24,7 +24,7 @@ function PrivateRoute() {
   }, []);
 
   if (loading) {
-    return <h3>Loading...</h3>;
+    return <h3 data-test-id="loading">Loading...</h3>;
   }
 
   return user ? (

--- a/src/components/PrivateRoute/index.tsx
+++ b/src/components/PrivateRoute/index.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react';
-import { Navigate, Outlet, useOutletContext } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 
+import Header from 'components/Header';
 import { getItem } from 'helpers/localStorage';
 import type { User } from 'types/User';
-
-type ContextType = User;
 
 import { LOGIN_URL } from '../../constants';
 
@@ -16,7 +15,7 @@ function PrivateRoute() {
     const fetchCurrentUser = async () => {
       const userProfile = getItem('UserProfile');
       if (userProfile?.user) {
-        setUser({ ...userProfile.user });
+        setUser({ name: userProfile.user.name, email: userProfile.user.email, avatarUrl: userProfile.user.avatar_url });
       }
 
       setLoading(false);
@@ -28,11 +27,14 @@ function PrivateRoute() {
     return <h3>Loading...</h3>;
   }
 
-  return user ? <Outlet context={user} /> : <Navigate to={LOGIN_URL} />;
+  return user ? (
+    <>
+      <Header user={user} />
+      <Outlet />
+    </>
+  ) : (
+    <Navigate to={LOGIN_URL} />
+  );
 }
 
-export default PrivateRoute;
-
-export function useUser() {
-  return useOutletContext<ContextType>();
-}
+export default PrivateRoutes;

--- a/src/components/PrivateRoute/index.tsx
+++ b/src/components/PrivateRoute/index.tsx
@@ -37,4 +37,4 @@ function PrivateRoute() {
   );
 }
 
-export default PrivateRoutes;
+export default PrivateRoute;

--- a/src/components/Sidebar/Sidebar.module.scss
+++ b/src/components/Sidebar/Sidebar.module.scss
@@ -1,0 +1,5 @@
+.sidebar {
+  border: 5px bla solid;
+
+  background: rgba(30, 30, 30, 0.9);
+}

--- a/src/components/Sidebar/index.test.tsx
+++ b/src/components/Sidebar/index.test.tsx
@@ -1,0 +1,52 @@
+/* eslint-disable camelcase */
+import { BrowserRouter } from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AuthAdapter from 'adapters/authAdapter';
+import { User } from 'types/User';
+
+import Sidebar from '.';
+import { setItem } from '../../helpers/localStorage';
+
+const mockTokenData = {
+  access_token: 'test_access_token',
+  refresh_token: 'test_refresh_token',
+  token_type: 'Bearer',
+  expires_in: 7200,
+  created_at: 1677045997,
+};
+
+const mockUserProfileData = {
+  email: 'testemail@gmail.com',
+  name: 'TestName',
+  avatar_url: 'https://secure.gravatar.com/avatar/6733d09432e89459dba795de8312ac2d',
+};
+
+describe('Sidebar', () => {
+  const user: User = { name: 'Test User', email: 'testemail@email.com', avatarUrl: 'an-avatar-url' };
+
+  test("renders a sidebar on the page with the user's name, profile image", () => {
+    render(<Sidebar user={user} />, { wrapper: BrowserRouter });
+
+    expect(screen.getByTestId('username')).toHaveTextContent(user.name);
+
+    const profileImage = screen.getByAltText('profile') as HTMLImageElement;
+    expect(profileImage.src).toContain('an-avatar-url');
+  });
+
+  test('renders a sidebar on the page with a logout button that when clicked, calls Logout adapter', async () => {
+    setItem('UserProfile', { auth: mockTokenData, user: mockUserProfileData });
+
+    const mockLogout = jest.spyOn(AuthAdapter, 'logout');
+
+    render(<Sidebar user={user} />, { wrapper: BrowserRouter });
+
+    const submitButton = screen.getByRole('button', { name: 'Logout' });
+
+    await userEvent.click(submitButton);
+
+    expect(mockLogout).toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/index.test.tsx
+++ b/src/components/Sidebar/index.test.tsx
@@ -8,15 +8,7 @@ import AuthAdapter from 'adapters/authAdapter';
 import { User } from 'types/User';
 
 import Sidebar from '.';
-import { setItem } from '../../helpers/localStorage';
-
-const mockTokenData = {
-  access_token: 'test_access_token',
-  refresh_token: 'test_refresh_token',
-  token_type: 'Bearer',
-  expires_in: 7200,
-  created_at: 1677045997,
-};
+// import * as localStorage from '../../helpers/localStorage';
 
 const mockUserProfileData = {
   email: 'testemail@gmail.com',
@@ -25,21 +17,25 @@ const mockUserProfileData = {
 };
 
 describe('Sidebar', () => {
-  const user: User = { name: 'Test User', email: 'testemail@email.com', avatarUrl: 'an-avatar-url' };
+  const user: User = { name: 'Test User', email: 'testemail@email.com', avatarUrl: mockUserProfileData.avatar_url };
 
-  test("renders a sidebar on the page with the user's name, profile image", () => {
+  test("renders a sidebar on the page with the user's name and avatar image", () => {
     render(<Sidebar user={user} />, { wrapper: BrowserRouter });
 
     expect(screen.getByTestId('username')).toHaveTextContent(user.name);
 
-    const profileImage = screen.getByAltText('profile') as HTMLImageElement;
-    expect(profileImage.src).toContain('an-avatar-url');
+    const profileImage = screen.getByTestId('sidebar-avatar') as HTMLImageElement;
+    expect(profileImage.src).toContain(mockUserProfileData.avatar_url);
   });
 
-  test('renders a sidebar on the page with a logout button that when clicked, calls Logout adapter', async () => {
-    setItem('UserProfile', { auth: mockTokenData, user: mockUserProfileData });
-
+  test('renders a sidebar on the page with a logout button that when clicked, calls Logout adapter and removes storage', async () => {
     const mockLogout = jest.spyOn(AuthAdapter, 'logout');
+
+    // jest.spyOn(localStorage, 'getItem').mockImplementation(() => {
+    //   return { auth: 'mockTokenData', user: mockUserProfileData };
+    // });
+
+    // const mockStorageClear = jest.spyOn(localStorage, 'clearItem');
 
     render(<Sidebar user={user} />, { wrapper: BrowserRouter });
 
@@ -47,6 +43,10 @@ describe('Sidebar', () => {
 
     await userEvent.click(submitButton);
 
-    expect(mockLogout).toHaveBeenCalled();
+    expect(mockLogout).toBeCalledTimes(1);
+
+    // expect(mockStorageClear).toBeCalled();
+
+    // navigates to LOGIN URL
   });
 });

--- a/src/components/Sidebar/index.test.tsx
+++ b/src/components/Sidebar/index.test.tsx
@@ -8,12 +8,20 @@ import AuthAdapter from 'adapters/authAdapter';
 import { User } from 'types/User';
 
 import Sidebar from '.';
-// import * as localStorage from '../../helpers/localStorage';
+import * as myStorage from '../../helpers/localStorage';
 
 const mockUserProfileData = {
   email: 'testemail@gmail.com',
   name: 'TestName',
   avatar_url: 'https://secure.gravatar.com/avatar/6733d09432e89459dba795de8312ac2d',
+};
+
+const mockTokenData = {
+  access_token: 'test_access_token',
+  refresh_token: 'test_refresh_token',
+  token_type: 'Bearer',
+  expires_in: 7200,
+  created_at: 1677045997,
 };
 
 describe('Sidebar', () => {
@@ -31,11 +39,13 @@ describe('Sidebar', () => {
   test('renders a sidebar on the page with a logout button that when clicked, calls Logout adapter and removes storage', async () => {
     const mockLogout = jest.spyOn(AuthAdapter, 'logout');
 
-    // jest.spyOn(localStorage, 'getItem').mockImplementation(() => {
-    //   return { auth: 'mockTokenData', user: mockUserProfileData };
-    // });
+    // const mockClearToken = jest.spyOn(myStorage, 'clearItem');
 
-    // const mockStorageClear = jest.spyOn(localStorage, 'clearItem');
+    const storageMock = jest.spyOn(myStorage, 'getItem').mockImplementationOnce(() => {
+      return { auth: mockTokenData, user: mockUserProfileData };
+    });
+
+    expect(myStorage.getItem('UserProfile')).not.toBeNull();
 
     render(<Sidebar user={user} />, { wrapper: BrowserRouter });
 
@@ -45,8 +55,11 @@ describe('Sidebar', () => {
 
     expect(mockLogout).toBeCalledTimes(1);
 
-    // expect(mockStorageClear).toBeCalled();
+    expect(myStorage.getItem('UserProfile')).toBeNull();
 
     // navigates to LOGIN URL
+    // useNavigate is not called because redirect is handled in axios interceptor? Mock window.location.href instead?
+
+    storageMock.mockRestore();
   });
 });

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -24,13 +24,16 @@ function Sidebar({ user }: SidebarProps) {
   };
 
   return (
-    <aside className={`${styles.sidebar} fixed top-0 right-0 flex h-screen w-1/6 min-w-fit flex-col gap-10 p-0`}>
+    <aside
+      data-test-id="sidebar"
+      className={`${styles.sidebar} fixed top-0 right-0 flex h-screen w-1/6 min-w-fit flex-col gap-10 p-0`}
+    >
       <div className="flex h-16 flex-col items-center justify-between px-5 md:flex-row md:border-b md:border-b-white">
         <span data-test-id="username" className="pt-2 font-bold text-white">
           {user.name}
         </span>
         <img
-          data-test-id="avatar"
+          data-test-id="sidebar-avatar"
           className="cursor-pointer rounded-full"
           height={36}
           width={36}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -29,7 +29,7 @@ function Sidebar({ user }: SidebarProps) {
         <span className="pt-2 font-bold text-white">{user.name}</span>
         <img className="cursor-pointer rounded-full" height={36} width={36} src={user.avatarUrl} alt="profile"></img>
       </div>
-      <button onClick={performLogout} className="left-5 text-xl text-white opacity-50">
+      <button onClick={performLogout} className="relative left-5 self-start text-xl text-white opacity-50">
         Logout
       </button>
     </aside>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -26,8 +26,17 @@ function Sidebar({ user }: SidebarProps) {
   return (
     <aside className={`${styles.sidebar} fixed top-0 right-0 flex h-screen w-1/6 min-w-fit flex-col gap-10 p-0`}>
       <div className="flex h-16 flex-col items-center justify-between px-5 md:flex-row md:border-b md:border-b-white">
-        <span className="pt-2 font-bold text-white">{user.name}</span>
-        <img className="cursor-pointer rounded-full" height={36} width={36} src={user.avatarUrl} alt="profile"></img>
+        <span data-test-id="username" className="pt-2 font-bold text-white">
+          {user.name}
+        </span>
+        <img
+          data-test-id="avatar"
+          className="cursor-pointer rounded-full"
+          height={36}
+          width={36}
+          src={user.avatarUrl}
+          alt="profile"
+        ></img>
       </div>
       <button onClick={performLogout} className="relative left-5 self-start text-xl text-white opacity-50">
         Logout

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom';
+
+import AuthAdapter from 'adapters/authAdapter';
+import { getItem, clearItem } from 'helpers/localStorage';
+import { User } from 'types/User';
+
+import styles from './Sidebar.module.scss';
+import { LOGIN_URL } from '../../constants';
+
+type SidebarProps = {
+  user: User;
+};
+
+function Sidebar({ user }: SidebarProps) {
+  const navigate = useNavigate();
+
+  const performLogout = async (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+
+    const accessToken = getItem('UserProfile')?.auth.access_token;
+    await AuthAdapter.logout(accessToken);
+    clearItem('UserProfile');
+    navigate(LOGIN_URL);
+  };
+
+  return (
+    <aside className={`${styles.sidebar} fixed top-0 right-0 flex h-screen w-1/6 min-w-fit flex-col gap-10 p-0`}>
+      <div className="flex h-16 flex-col items-center justify-between px-5 md:flex-row md:border-b md:border-b-white">
+        <span className="pt-2 font-bold text-white">{user.name}</span>
+        <img className="cursor-pointer rounded-full" height={36} width={36} src={user.avatarUrl} alt="profile"></img>
+      </div>
+      <button onClick={performLogout} className="left-5 text-xl text-white opacity-50">
+        Logout
+      </button>
+    </aside>
+  );
+}
+
+export default Sidebar;

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,15 +1,9 @@
-import { useUser } from 'components/PrivateRoute';
-
 const HomeScreen = (): JSX.Element => {
-  const user = useUser();
-
   return (
     <>
       <div className="my-8 text-white opacity-50" data-test-id="app-main-heading">
         Home Screen
       </div>
-      {/* TODO: Remove when header implemented in #19 */}
-      <div className="my-8 text-white opacity-50">{`${user?.name} - ${user?.email} - ${user?.avatarUrl}`}</div>
     </>
   );
 };


### PR DESCRIPTION
- Close: #19 
- Close: #18 
- Close: #22 

## What happened 👀

- [x] Changed from passing the User to OutletContext in Private Route to passing the User directly to a Header component from the Private Route
- [x] Allowed the user to logout by opening a sidebar by clicking on their profile image in the header.
- [x] Tests - (**Still having issues asserting on localstorage mocking calls (this case asserting function called to clear cookie upon logout). It doesnt seem to get called in tests as I think the interceptor will re-direct to login page first. 
Also infinite loop in tests for authenticated route with no user located in private route test with `test.skip`**

## Insight 📝

## Proof Of Work 📹

Showing the Header on all routes where the user has been authenticated:

<img width="1505" alt="Screenshot 2023-03-09 at 16 45 56" src="https://user-images.githubusercontent.com/8955671/223984016-ea460628-d866-4683-aa07-511bc458fe02.png">

Clicking on the User's image displays the sidebar where logout can be performed:

<img width="1501" alt="Screenshot 2023-03-13 at 12 12 22" src="https://user-images.githubusercontent.com/8955671/224613432-326d99f6-c256-40bc-8a07-a4d26c4a6c41.png">

